### PR TITLE
Added 'UnixLike' as valid OS type.

### DIFF
--- a/rubrik_cdm/physical.py
+++ b/rubrik_cdm/physical.py
@@ -322,13 +322,13 @@ class Physical(Api):
             return self.post('internal', '/host/share', config, timeout)
 
     def assign_physical_host_fileset(self, hostname, fileset_name, operating_system, sla_name, include=None, exclude=None, exclude_exception=None, follow_network_shares=False, backup_hidden_folders=False, timeout=30):  # pylint: ignore
-        """Assign a Fileset to a Linux or Windows machine. If you have multiple Filesets with identical names, you will need to populate the Filesets properties (i.e this functions keyword arguments)
+        """Assign a Fileset to a Linux, Unix or Windows machine. If you have multiple Filesets with identical names, you will need to populate the Filesets properties (i.e this functions keyword arguments)
         to find a specific match. Filesets with identical names and properties are not supported.
 
         Arguments:
             hostname {str} -- The hostname or IP Address of the physical host you wish to associate to the Fileset.
-            fileset_name {str} -- The name of the Fileset you wish to assign to the Linux or Windows host.
-            operating_system {str} -- The operating system of the physical host you are assigning a Fileset to. (choices: {Linux, Windows})
+            fileset_name {str} -- The name of the Fileset you wish to assign to the Linux, Unix or Windows host.
+            operating_system {str} -- The operating system of the physical host you are assigning a Fileset to. (choices: {Linux, Windows, UnixLike})
             sla_name {str} -- The name of the SLA Domain to associate with the Fileset.
 
         Keyword Arguments:
@@ -347,7 +347,7 @@ class Physical(Api):
 
         self.function_name = inspect.currentframe().f_code.co_name
 
-        valid_operating_system = ['Linux', 'Windows']
+        valid_operating_system = ['Linux', 'Windows', 'UnixLike']
 
         if operating_system not in valid_operating_system:
             raise InvalidParameterException("The assign_physical_host_fileset() operating_system argument must be one of the following: {}.".format(


### PR DESCRIPTION
Added 'UnixLike' as valid OS type in order to be able to assign filesets to AIX and other Unix systems.

# Description

Added 'UnixLike' as valid OS type in order to be able to assign filesets to AIX and other Unix systems. Currently, it is not possible as AIX and other Unix systems are not listed using "Linux" OS type.

## Motivation and Context

Currently, it is not possible to assign filesets to AIX and other Unix systems as they are not listed using "Linux" OS type.

## How Has This Been Tested?

In my lab by assigning a fileset to an AIX host.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-python/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
